### PR TITLE
Fix bug in output buffering cleanup during stream initialization

### DIFF
--- a/src/libsse.php
+++ b/src/libsse.php
@@ -101,7 +101,7 @@ class SSE {
 		}
 		@ini_set('zlib.output_compression',0);
 		@ini_set('implicit_flush',1);
-		for($i = 0; $i < ob_get_level(); $i++){
+                while (ob_get_level() != 0) {
 			ob_end_flush();
 		}
 		ob_implicit_flush(1);


### PR DESCRIPTION
There is a bug in the output buffer cleanup during initialization. In a for() loop, the conditional will be evaluated on every iteration through the loop. Because ob_end_flush() is called in the loop, the value returned by ob_get_level() is going to change on each iteration, causing some of the buffers not to be  flushed and ended (if the initial value is 2, only 1 will be processed). I've altered the loop to be a while() loop that goes until all the output buffering is disabled. Alternatively, the for() loop could be adjusted to cache the initial value of ob_get_level(), and test against that in the conditional clause.

I tried both methods, and either seems to work fine on the test applications. With my proposed change, I injected a few different levels of output buffering in, and logged each call to ob_end_flush(), to make sure it cleaned up the appropriate number of buffering levels.