### PR TITLE
X-Accel-Buffering header must be set to "no" instead of "off", otherwise nginx will not disable output buffering.

### DIFF
--- a/src/SSE.php
+++ b/src/SSE.php
@@ -266,7 +266,7 @@ class SSE implements ArrayAccess
         $response = new StreamedResponse($callback, Response::HTTP_OK, array(
             'Content-Type' => 'text/event-stream',
             'Cache-Control' => 'no-cache',
-            'X-Accel-Buffering' => 'off' // Disables FastCGI Buffering on Nginx
+            'X-Accel-Buffering' => 'no' // Disables FastCGI Buffering on Nginx
         ));
 
         if($this->allow_cors){


### PR DESCRIPTION
Synopsis: https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering