### PR TITLE
Use apcu functions via polyfill for PHP 5.3+ compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
   },
 
   "suggest": {
-    "predis/predis": "For using RedisMechnism"
+    "predis/predis": "For using RedisMechnism",
+    "symfony/polyfill-apcu": "For APCMecnism on PHP < 7.0"
   }
 }

--- a/src/Mechnisms/ApcMechnism.php
+++ b/src/Mechnisms/ApcMechnism.php
@@ -46,8 +46,8 @@ class ApcMechnism extends AbstractMechnism
     public function __construct(array $args)
     {
         parent::__construct($args);
-        if (!extension_loaded('apc')) {
-            throw new \RuntimeException('Unable to use ApcMechnism as APC is disabled');
+        if (!function_exists('apcu_fetch')) {
+            throw new \RuntimeException('Unable to use ApcMechnism as APC/APCU is disabled');
         }
     }
 
@@ -56,7 +56,7 @@ class ApcMechnism extends AbstractMechnism
      */
     public function get($key)
     {
-        return apc_fetch($key);
+        return apcu_fetch($key);
     }
 
     /**
@@ -64,7 +64,7 @@ class ApcMechnism extends AbstractMechnism
      */
     public function set($key, $value)
     {
-        return apc_store($key, $value, $this->lifetime);
+        return apcu_store($key, $value, $this->lifetime);
     }
 
     /**
@@ -72,7 +72,7 @@ class ApcMechnism extends AbstractMechnism
      */
     public function delete($key)
     {
-        return apc_delete($key);
+        return apcu_delete($key);
     }
 
     /**
@@ -80,6 +80,6 @@ class ApcMechnism extends AbstractMechnism
      */
     public function has($key)
     {
-        return apc_exists($key);
+        return apcu_exists($key);
     }
 }


### PR DESCRIPTION
`apc_*` functions are no longer available in PHP 7+, so with this
polyfill we can support all used PHP versions.