### PR TITLE
Solves an issue with `count` behavior in PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "tonyhhyip/sse",
-  "description": "An easy-to-use, object-orienlated library for Server-Sent Events",
+  "description": "An easy-to-use, object-oriented library for Server-Sent Events",
   "version": "2.1.1",
   "type": "library",
   "keywords": ["sse"],

--- a/src/Data.php
+++ b/src/Data.php
@@ -65,7 +65,7 @@ class Data implements DataInterface
         if (!static::$initial)
             static::fireOnInitial();
 
-        if (!array_key_exists($mechnism, static::$registers) || count(static::$registers[$mechnism]) === 0)
+        if (!array_key_exists($mechnism, static::$registers) || empty(static::$registers[$mechnism]))
             throw new \InvalidArgumentException("$mechnism Mechnism has not been registered");
 
         $mechnism = static::$registers[$mechnism];


### PR DESCRIPTION
Replace `count` function with `empty` function.

Closes licson0729/libSSE-php#30